### PR TITLE
Add Bower Package Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/calevans/external.git"
+    "url": "git://github.com/settermjd/external.git"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/settermjd/external.git"
+    "url": "git://github.com/calevans/external.git"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,6 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/settermjd/external",
-  "dependencies": {
-    "reveal.js": "~3.3.0"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/calevans/external.git"

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "external.js",
+  "name": "external-js",
   "authors": [
     "Cal Evans <cal@calevans.com>",
     "Matthew Setter <matthew@matthewsetter.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "External.js",
+  "name": "external.js",
   "authors": [
     "Cal Evans <cal@calevans.com>",
     "Matthew Setter <matthew@matthewsetter.com>"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Matthew Setter <matthew@matthewsetter.com>"
   ],
   "description": "External file importer for reveal.js",
-  "version": "0.0.2",
+  "version": "1.0.1",
   "main": "external/external.js",
   "keywords": [
     "reveal.js",

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "External.js",
+  "authors": [
+    "Cal Evans <cal@calevans.com>",
+    "Matthew Setter <matthew@matthewsetter.com>"
+  ],
+  "description": "External file importer for reveal.js",
+  "version": "0.0.2",
+  "main": "external/external.js",
+  "keywords": [
+    "reveal.js",
+    "external.js"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/settermjd/external",
+  "dependencies": {
+    "reveal.js": "~3.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/calevans/external.git"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This PR adds [Bower package support](https://bower.io/docs/creating-packages/). The intent is to make the package more universally available and installable. In addition to cloning the repository or downloading external.js, it will be able to be installed via Bower, and eventually found in a [Bower package search](https://bower.io/search/). 
